### PR TITLE
UNTESTED: implement furnace recipe quality selection logic (Issue #50)

### DIFF
--- a/sw-rates-lib/configurations/crafting-machine.lua
+++ b/sw-rates-lib/configurations/crafting-machine.lua
@@ -402,6 +402,75 @@ logic.fill_progression = function(result, options)
     end
 end
 
+---@param quality LuaQualityPrototype
+---@param quality_change integer
+---@return LuaQualityPrototype
+local function shift_quality(quality, quality_change)
+    while quality_change > 0 and quality.next do
+        quality = quality.next
+        quality_change = quality_change - 1
+    end
+    while quality_change < 0 and quality.previous do
+        quality = quality.previous
+        quality_change = quality_change + 1
+    end
+    return quality
+end
+
+---@param quality LuaQualityPrototype
+---@param quality_min LuaQualityPrototype?
+---@param quality_max LuaQualityPrototype?
+---@return LuaQualityPrototype
+local function clamp_quality(quality, quality_min, quality_max)
+    if (quality_min and quality.level < quality_min.level) then
+        quality = quality_min
+    end
+    if (quality_max and quality.level > quality_max.level) then
+        quality = quality_max
+    end
+    return quality
+end
+
+--- Implements https://lua-api.factorio.com/latest/auxiliary/furnace-recipe-selection.html
+--- for one candidate recipe: given the item ingredient prototype (as
+--- declared on the recipe) and the quality of the item actually detected,
+--- returns the recipe quality the furnace would run at - or nil if this
+--- item's quality could never have come out of this recipe at all.
+---@param recipe LuaRecipePrototype
+---@param item_ingredient ItemIngredientPrototype
+---@param item_quality LuaQualityPrototype
+---@return LuaQualityPrototype?
+local function get_furnace_recipe_quality(recipe, item_ingredient, item_quality)
+    local recipe_quality
+    if (not recipe.can_set_quality) then
+        recipe_quality = prototypes.quality.normal
+    else
+        local quality_change = item_ingredient.quality_change or 0
+        local has_quality_control = quality_change ~= 0
+            or item_ingredient.quality_min ~= nil
+            or item_ingredient.quality_max ~= nil
+
+        if (not has_quality_control) then
+            recipe_quality = item_quality
+        else
+            recipe_quality = shift_quality(item_quality, -quality_change)
+        end
+    end
+
+    -- Validity check from the docs, applies uniformly to all three cases
+    -- above: does recipe_quality, transformed forward again, actually
+    -- require the item quality we observed?
+    local required_item_quality = clamp_quality(
+        shift_quality(recipe_quality, item_ingredient.quality_change or 0),
+        item_ingredient.quality_min, item_ingredient.quality_max)
+
+    if (required_item_quality ~= item_quality) then
+        return nil
+    end
+
+    return recipe_quality
+end
+
 ---@param prototype LuaEntityPrototype
 ---@param inputs Rates.Analyzer.EntityInputs
 ---@return { recipe: LuaRecipePrototype, quality: LuaQualityPrototype }[]
@@ -443,10 +512,15 @@ local function get_furnace_recipes(prototype, inputs)
             for _, possible_recipe in pairs(item_recipes) do
                 if (can_craft(prototype, possible_recipe)) then
                     if (#possible_recipe.ingredients == 1) then
-                        result[#result + 1] = { recipe = possible_recipe, quality = item.quality }
+                        local item_ingredient = possible_recipe.ingredients[1]
+                        local recipe_quality = get_furnace_recipe_quality(possible_recipe, item_ingredient, item.quality)
+                        if (recipe_quality) then
+                            result[#result + 1] = { recipe = possible_recipe, quality = recipe_quality }
+                        end
                     elseif (#possible_recipe.ingredients == 2) then
                         local i = possible_recipe.ingredients[1].type == "item" and 2 or 1
                         local other_ingredient = possible_recipe.ingredients[i]
+                        local item_ingredient = possible_recipe.ingredients[i == 1 and 2 or 1]
                         if (other_ingredient.type == "fluid") then
                             local has_fluid = false
                             for _, fluid in pairs(fluid_set) do
@@ -456,7 +530,10 @@ local function get_furnace_recipes(prototype, inputs)
                                 end
                             end
                             if (has_fluid) then
-                                result[#result + 1] = { recipe = possible_recipe, quality = item.quality }
+                                local recipe_quality = get_furnace_recipe_quality(possible_recipe, item_ingredient, item.quality)
+                                if (recipe_quality) then
+                                    result[#result + 1] = { recipe = possible_recipe, quality = recipe_quality }
+                                end
                             end
                         end
                     end


### PR DESCRIPTION
## Root cause

I checked the current source: `quality_min`, `quality_max`, and
`quality_change` appear **nowhere** in the library. Every candidate recipe
in `get_furnace_recipes` is assigned `quality = item.quality` (or
`prototypes.quality.normal` for the fluid-only branch) unconditionally,
the detected item's own quality is just copied over, regardless of what the
recipe itself says about quality.

That's the bug. Recipes can declare, per item ingredient, a `quality_min`,
`quality_max`, and/or `quality_change`, and separately a `can_set_quality`
flag, none of which the current code reads at all.

Factorio's own furnace recipe selection is documented at
**[Furnace Recipe Selection](https://lua-api.factorio.com/latest/auxiliary/furnace-recipe-selection.html)**.
Quoting the relevant part:

> After [picking a recipe by ingredient name], the recipe quality is chosen
> based on the item ingredient's quality. There are three possible paths:
> - If `can_set_quality` is `false`, the normal recipe quality is chosen.
> - If `can_set_quality` is `true` and the item ingredient does not have
>   quality control (`quality_change`, `quality_min`, `quality_max` all
>   unset), the recipe quality is set to the item ingredient's quality.
> - If `can_set_quality` is `true` and the item ingredient *does* have
>   quality control, the recipe quality is set to the reverse of
>   `quality_change` applied to the item ingredient's quality.
>
> If the chosen recipe quality requires a different item ingredient quality
> than the available item ingredient's quality, the recipe is not selected.

This gives a complete, unambiguous, engine-authoritative algorithm: this
isn't a case of reverse-engineering undocumented behavior, the fix is just
implementing what's already specified.


## What this deliberately does *not* change

`get_from_entity` already treats an ambiguous set of furnace candidates as
a `meta` configuration (multiple alternatives shown to the user), rather
than guessing. I left that behavior alone. The docs also describe a strict
priority order for furnace recipe selection itself (item+fluid match tried
first, then item-only, then fluid-only, each picked by first match in
inventory order) which the current code doesn't enforce  it just unions
candidates from all three groups. That's a real, separate gap from what
issue #50 is about, and fixing it would change how often the "meta"
alternative UI shows up (fewer, more precise single-recipe resolutions
instead of ambiguous groups)  I'd treat that as its own follow-up rather
than folding it into this patch, since it changes UX behavior beyond just
correctness.

## What has to be tested:

- **`LuaQualityPrototype.level`, `.next`, `.previous`**  I'm using these
  based on how `.next`/`.previous` are already used elsewhere for quality
  chain-walking; `.level` for min/max comparison is the standard way mods
  compare quality tiers, but I haven't confirmed it against 2.1's actual
  runtime API docs.
- **Whether `item_ingredient.quality_change/_min/_max` read correctly off
  `RecipePrototype.ingredients[n]`** for both the 1-ingredient and
  2-ingredient cases  the field names match `ItemIngredientPrototype`,
  but I'd want a real recipe with these set to confirm indexing.
- **Multiple-product recipes**  I only looked at the ingredient side.
  If any furnace recipe has `quality_min`/`max`/`change` on a *product*
  instead of (or in addition to) the ingredient, this patch doesn't cover
  that; the docs page is specifically about ingredient-side quality
  control for recipe *selection*, so I believe this is out of scope, but
  worth the author double-checking.

## Suggested test plan

1. A recipe with no quality control at all => confirm output quality still
   just follows input quality (regression check, this already worked).
2. A recipe with `quality_change = 1` on its item ingredient, fed items at
   `uncommon` => confirm the furnace resolves to the recipe running at
   `normal` quality (reverse of +1), and that it's correctly rejected as a
   candidate if fed a `normal`-quality item instead (since normal+1 ≠
   normal, i.e. wrong recipe_quality for that observed item).
3. A recipe with `quality_min` set above `normal` => confirm sub-minimum
   quality items correctly produce *no* candidate for that recipe.
4. A recipe with `can_set_quality = false` => confirm it always resolves to
   `normal`, and is excluded entirely when fed a non-normal item (unless a
   `quality_change` on the ingredient makes normal the mathematically
   correct source quality for the observed item).

## Confidence

Medium-high on the algorithm itself (directly transcribed from Wube's own
documented spec, not inferred), lower on the exact Factorio API field
names/behavior in bullet points above, since I can't load this in-game.